### PR TITLE
feat: add custom format date

### DIFF
--- a/src/components/CommentsSSR.astro
+++ b/src/components/CommentsSSR.astro
@@ -3,6 +3,7 @@ import { collection, doc, getDocs } from "firebase/firestore";
 import { db } from "../js/firestoreConfig.js";
 import PersonIcon from "../assets/PersonIcon.jsx";
 import CommentRatingButtons from "./CommentRatingButtons.jsx";
+import { getCustomFormatDate } from "../js/utils.js";
 
 const { id } = Astro.props;
 
@@ -24,6 +25,15 @@ const filtredByPostCommens = comments.filter(
 const filtredByPostAndDraftComments = filtredByPostCommens.filter(
   (comment) => comment.data.draft === 'false'
 );
+
+const renderCustomDate = (date) =>{
+  const arr = date.split("");
+  [arr[0], arr[3]] = [arr[3], arr[0]];
+  [arr[1], arr[4]] = [arr[4], arr[1]];
+  const usaFormatDate = arr.join("");
+  const ms = Date.parse(usaFormatDate)
+  return getCustomFormatDate(ms)
+}
 ---
 
 {
@@ -34,7 +44,7 @@ const filtredByPostAndDraftComments = filtredByPostCommens.filter(
         <div class="info-about-comment">
           <PersonIcon />
           <h4 class="comment-author">{comment.data.author}</h4>
-          <p>{comment.data.date}</p>
+          <p>{renderCustomDate(comment.data.date)}</p>
         </div>
         <p class="comment__text">{comment.data.comment}</p>
         <CommentRatingButtons

--- a/src/components/NewCommentForm.jsx
+++ b/src/components/NewCommentForm.jsx
@@ -7,6 +7,7 @@ import useFormWithValidation from "../js/FormValidator";
 import { doc, setDoc } from "firebase/firestore";
 
 import { db } from "../js/firestoreConfig";
+import { formatDate } from "../js/utils";
 
 export function NewCommentForm({ id }) {
   const { values, handleChange, errors, isValid, resetForm } =
@@ -36,7 +37,7 @@ export function NewCommentForm({ id }) {
       draft: true,
       author: values.author,
       comment: values.comment,
-      date: new Date().toLocaleDateString(),
+      date: formatDate(Date.now()),
       likes: 0,
       dislikes: 0,
     };

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -10,21 +10,20 @@ export const slugify = (text) => {
 };
 
 export const formatDate = (date) => {
+  let d = new Date(date),
+    month = "" + (d.getMonth() + 1),
+    day = "" + d.getDate(),
+    year = d.getFullYear();
+  if (month.length < 2) month = "0" + month;
+  if (day.length < 2) day = "0" + day;
+
+  return [day, month, year].join(".");
+};
+
+export const getCustomFormatDate = (date) => {
   let today = new Date();
   let yesterday = new Date();
   let dateValue = new Date(date);
-
-  const getCustomFormatDate = (date) => {
-    var d = new Date(date),
-      month = "" + (d.getMonth() + 1),
-      day = "" + d.getDate(),
-      year = d.getFullYear();
-
-    if (month.length < 2) month = "0" + month;
-    if (day.length < 2) day = "0" + day;
-
-    return [day, month, year].join(".");
-  };
 
   const dropHMS = (date) => {
     date.setHours(0);
@@ -44,7 +43,7 @@ export const formatDate = (date) => {
     } else if (yesterday.getTime() === dateValue.getTime()) {
       return "Вчера";
     } else {
-      return getCustomFormatDate(date);
+      return formatDate(date);
     }
   }
 };


### PR DESCRIPTION
1. Переписана функция `formatDate`, теперь она стандартизирует даты в формате `дд.мм.гггг`

2. Создана функция `getCustomFormatDate` которая сравнивает дату создания коментария и текущую дату пользователя и на основе сравнения выводит текст "Сегодня", "Вчера" или дату в цифровом формате `дд.мм.гггг` с помощью функции `formatDate`.

    Внутренняя функция `dropHMS` сбрасывает часы, минуты и секунды чтобы можно было сравнивать даты методом `getTime`

3. Создана функция `renderCustomDate` которая рендерит полученную с firebase дату. Функция изменяет полученную дату формата `дд.мм.гггг` на `мм.дд.гггг`, потому что только в таком формате можно передать строку методу `Date.parse()`. Метод `Date.parse()` в свою очеред возвращает дату в милисекундах и передаёт функции `getCustomFormatDate`. Нужно это потому что дату в строковом формате получаемую с firebase нельзя напрямую передать методу `new Date()` который использует функция `getCustomFormatDate`.